### PR TITLE
Https schema url

### DIFF
--- a/README.html
+++ b/README.html
@@ -120,10 +120,10 @@ body{font-size:16px;}
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 }
-</style><title>README</title></head><body><p><a href="http://travis-ci.org/lassebunk/item"><img alt="Build Status" src="https://secure.travis-ci.org/lassebunk/item.png" /></a></p>
+</style><title>README</title></head><body><p><a href="https://travis-ci.org/lassebunk/item"><img alt="Build Status" src="https://secure.travis-ci.org/lassebunk/item.png" /></a></p>
 <h1 id="item">Item</h1>
 <p>Item is a Ruby on Rails plugin for implementing semantic markup (microdata) without messing up the view code.</p>
-<p>See <a href="http://schema.org/docs/schemas.html">Schema.org</a> for valid microdata.</p>
+<p>See <a href="https://schema.org/docs/schemas.html">Schema.org</a> for valid microdata.</p>
 <h2 id="installation">Installation</h2>
 <p>Add this line to your application's <em>Gemfile</em>:</p>
 <pre><code class="ruby">gem 'item'
@@ -142,7 +142,7 @@ body{font-size:16px;}
 </code></pre>
 
 <p>This will generate the following HTML:</p>
-<pre><code class="html">&lt;div itemscope itemtype=&quot;http://schema.org/Product&quot;&gt;
+<pre><code class="html">&lt;div itemscope itemtype=&quot;https://schema.org/Product&quot;&gt;
   ...
 &lt;/div&gt;
 </code></pre>
@@ -168,7 +168,7 @@ body{font-size:16px;}
 <h4 id="link-values">Link values</h4>
 <p>To define a link to an enumeration member, e.g. <a href="">ItemAvailability</a></p>
 <h2 id="example">Example</h2>
-<p>The following is the Product <a href="http://schema.org/Product">example</a> on <a href="http://schema.org">Schema.org</a> rewritten with Item. In your view:</p>
+<p>The following is the Product <a href="https://schema.org/Product">example</a> on <a href="https://schema.org">Schema.org</a> rewritten with Item. In your view:</p>
 <pre><code class="erb">&lt;% scope :product do %&gt;
   &lt;%= itemprop :name, &quot;Kenmore White 17\&quot; Microwave&quot; %&gt;
   &lt;%= image_tag &quot;kenmore-microwave-17in.jpg&quot; %&gt;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Item is a Ruby on Rails plugin for adding semantic markup (microdata) to your views without cluttering the view code.
 
-**What is Microdata?** [Microdata](http://schema.org) helps search engines show additional information about your content, for example product reviews.
+**What is Microdata?** [Microdata](https://schema.org) helps search engines show additional information about your content, for example product reviews.
 This can help attract visitors to your site:
 
 ![Microdata in SERPs](http://i.imgur.com/bCi0GHF.png)
@@ -43,7 +43,7 @@ To define an `itemscope`:
 The above will generate the following HTML:
 
 ```html
-<div itemscope itemtype="http://schema.org/Product">
+<div itemscope itemtype="https://schema.org/Product">
   ...
 </div>
 ```
@@ -89,7 +89,7 @@ To define a property that is also a scope:
 The above will generate the following HTML:
 
 ```html
-<div itemprop="review" itemscope itemtype="http://schema.org/Review">
+<div itemprop="review" itemscope itemtype="https://schema.org/Review">
   <span itemprop="name">Pete Anderson</span>
 </div>
 ```
@@ -107,7 +107,7 @@ Sometimes you need to define a type on scoped properties when this cannot be inf
 This will generate the following HTML:
 
 ```html
-<div itemprop="reviewRating" itemscope itemtype="http://schema.org/Review">
+<div itemprop="reviewRating" itemscope itemtype="https://schema.org/Review">
   ...
 </div>
 ```
@@ -139,7 +139,7 @@ This will generate the following HTML:
 
 #### Link properties
 
-To define a link to an enumeration member, e.g. [ItemAvailability](http://schema.org/ItemAvailability):
+To define a link to an enumeration member, e.g. [ItemAvailability](https://schema.org/ItemAvailability):
 
 ```erb
 <%= prop :availability, :in_stock %>
@@ -154,12 +154,12 @@ You can also do this by passing symbols as hash values:
 This will generate the following HTML:
 
 ```html
-<link itemprop="availability" href="http://schema.org/InStock" />
+<link itemprop="availability" href="https://schema.org/InStock" />
 ```
 
 ## Example
 
-The following is based on the [Product example](http://schema.org/Product) on [Schema.org](http://schema.org), rewritten with the Item gem. In your view:
+The following is based on the [Product example](https://schema.org/Product) on [Schema.org](https://schema.org), rewritten with the Item gem. In your view:
 
 ```erb
 <% scope :product do %>
@@ -205,14 +205,14 @@ I recommend using these (especially Google's) before releasing to production, so
 
 #### Google Structured Data Testing Tool
 
-[Google's Structured Data Testing Tool](http://www.google.com/webmasters/tools/richsnippets) is the tool I recommend using for making sure your microdata will validate.
+[Google's Structured Data Testing Tool](https://www.google.com/webmasters/tools/richsnippets) is the tool I recommend using for making sure your microdata will validate.
 If your microdata validates here, it will validate on Google SERPs.
 
 You can enter a URL or copy/paste HTML to validate. This means that you can test your development code, too.
 
 #### Bing Markup Validator
 
-[Bing's Markup Validator](http://www.bing.com/webmaster/diagnostics/markup/validator) appears to be easier to read, but it is not as strict as Google's tool.
+[Bing's Markup Validator](https://www.bing.com/webmaster/diagnostics/markup/validator) appears to be easier to read, but it is not as strict as Google's tool.
 
 #### Mida
 

--- a/item.gemspec
+++ b/item.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", "~> 1.6"
   s.add_development_dependency "rake"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", '~> 1.3.13'
 end

--- a/lib/item/view_helpers.rb
+++ b/lib/item/view_helpers.rb
@@ -68,7 +68,7 @@ module Item
 
         def href(name)
           name = name.to_s.gsub(/(^|_)(.)/) { $2.upcase }
-          "http://schema.org/#{name}"
+          "https://schema.org/#{name}"
         end
       end
     end

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -8,7 +8,7 @@ class ViewHelpersTest < ActionView::TestCase
       "content"
     end
 
-    assert_equal %{<div itemscope="itemscope" itemtype="http://schema.org/AggregateRating">content</div>},
+    assert_equal %{<div itemscope="itemscope" itemtype="https://schema.org/AggregateRating">content</div>},
                  content
   end
 
@@ -17,7 +17,7 @@ class ViewHelpersTest < ActionView::TestCase
       "content"
     end
 
-    assert_equal %{<something class="some-class" itemscope="itemscope" itemtype="http://schema.org/AggregateRating">content</something>},
+    assert_equal %{<something class="some-class" itemscope="itemscope" itemtype="https://schema.org/AggregateRating">content</something>},
                  content
   end
 
@@ -38,14 +38,14 @@ class ViewHelpersTest < ActionView::TestCase
   test "hidden prop" do
     content = prop(aggregate_rating: "Rating content", availability: :in_stock)
 
-    assert_equal %{<meta content="Rating content" itemprop="aggregateRating" />\n<link href="http://schema.org/InStock" itemprop="availability" />},
+    assert_equal %{<meta content="Rating content" itemprop="aggregateRating" />\n<link href="https://schema.org/InStock" itemprop="availability" />},
                  content
   end
 
   test "link prop" do
     content = prop(:availability, :in_stock)
 
-    assert_equal %{<link href="http://schema.org/InStock" itemprop="availability" />},
+    assert_equal %{<link href="https://schema.org/InStock" itemprop="availability" />},
                  content
   end
 
@@ -54,7 +54,7 @@ class ViewHelpersTest < ActionView::TestCase
       "content"
     end
 
-    assert_equal %{<div itemprop="aggregateRating" itemscope="itemscope" itemtype="http://schema.org/AggregateRating">content</div>},
+    assert_equal %{<div itemprop="aggregateRating" itemscope="itemscope" itemtype="https://schema.org/AggregateRating">content</div>},
                  content
   end
 
@@ -63,7 +63,7 @@ class ViewHelpersTest < ActionView::TestCase
       "content"
     end
 
-    assert_equal %{<something class="some-class" itemprop="aggregateRating" itemscope="itemscope" itemtype="http://schema.org/AggregateRating">content</something>},
+    assert_equal %{<something class="some-class" itemprop="aggregateRating" itemscope="itemscope" itemtype="https://schema.org/AggregateRating">content</something>},
                  content
   end
 
@@ -72,7 +72,7 @@ class ViewHelpersTest < ActionView::TestCase
       "content"
     end
 
-    assert_equal %{<div itemprop="aggregateRating" itemscope="itemscope" itemtype="http://schema.org/OtherType">content</div>},
+    assert_equal %{<div itemprop="aggregateRating" itemscope="itemscope" itemtype="https://schema.org/OtherType">content</div>},
                  content
   end
 
@@ -81,7 +81,7 @@ class ViewHelpersTest < ActionView::TestCase
       prop(:title, "My Title")
     end
 
-    assert_equal %{<div itemscope="itemscope" itemtype="http://schema.org/Product"><span itemprop="title">My Title</span></div>},
+    assert_equal %{<div itemscope="itemscope" itemtype="https://schema.org/Product"><span itemprop="title">My Title</span></div>},
                  content
   end
 
@@ -94,7 +94,7 @@ class ViewHelpersTest < ActionView::TestCase
       end
     end
 
-    assert_equal %{<div itemscope="itemscope" itemtype="http://schema.org/Product"><custom1 class="offers-container" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer"><custom2 class="price-container" itemprop="price">123.5</custom2><link href="http://schema.org/InStock" itemprop="availability" />\n<meta content="DKK" itemprop="priceCurrency" /><link href="http://schema.org/OtherValue" itemprop="otherKey" /></custom1></div>},
+    assert_equal %{<div itemscope="itemscope" itemtype="https://schema.org/Product"><custom1 class="offers-container" itemprop="offers" itemscope="itemscope" itemtype="https://schema.org/Offer"><custom2 class="price-container" itemprop="price">123.5</custom2><link href="https://schema.org/InStock" itemprop="availability" />\n<meta content="DKK" itemprop="priceCurrency" /><link href="https://schema.org/OtherValue" itemprop="otherKey" /></custom1></div>},
                  content
   end
 
@@ -110,7 +110,7 @@ class ViewHelpersTest < ActionView::TestCase
       end.html_safe
     end
 
-    assert_equal %{<div itemscope=\"itemscope\" itemtype=\"http://schema.org/Product\"><custom1 class=\"offers-container\"><custom2 class=\"price-container\">123.5</custom2></custom1><span itemprop=\"name\">Product Name</span></div>},
+    assert_equal %{<div itemscope=\"itemscope\" itemtype=\"https://schema.org/Product\"><custom1 class=\"offers-container\"><custom2 class=\"price-container\">123.5</custom2></custom1><span itemprop=\"name\">Product Name</span></div>},
                  content
   end
 
@@ -123,7 +123,7 @@ class ViewHelpersTest < ActionView::TestCase
       end
     end
 
-    assert_equal %{<div itemscope="itemscope" itemtype="http://schema.org/Product"><custom1 class="offers-container" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer"><custom2 class="price-container" itemprop="price">123.5</custom2><link href="http://schema.org/InStock" itemprop="availability" />\n<meta content="DKK" itemprop="priceCurrency" /><link href="http://schema.org/OtherValue" itemprop="otherKey" /></custom1></div>},
+    assert_equal %{<div itemscope="itemscope" itemtype="https://schema.org/Product"><custom1 class="offers-container" itemprop="offers" itemscope="itemscope" itemtype="https://schema.org/Offer"><custom2 class="price-container" itemprop="price">123.5</custom2><link href="https://schema.org/InStock" itemprop="availability" />\n<meta content="DKK" itemprop="priceCurrency" /><link href="https://schema.org/OtherValue" itemprop="otherKey" /></custom1></div>},
                  content
   end
 
@@ -139,7 +139,7 @@ class ViewHelpersTest < ActionView::TestCase
       end.html_safe
     end
 
-    assert_equal %{<div itemscope=\"itemscope\" itemtype=\"http://schema.org/Product\"><custom1 class=\"offers-container\"><custom2 class=\"price-container\">123.5</custom2></custom1><span itemprop=\"name\">Product Name</span></div>},
+    assert_equal %{<div itemscope=\"itemscope\" itemtype=\"https://schema.org/Product\"><custom1 class=\"offers-container\"><custom2 class=\"price-container\">123.5</custom2></custom1><span itemprop=\"name\">Product Name</span></div>},
                  content
   end
 end


### PR DESCRIPTION
Hello @lassebunk 
this PR changes all http schema.org urls to https, so we don't get mixed content warnings in browser when site is running on https.
Also I've fixed sqlite3 gem version to 1.3.13, because with 1.4 running tests throws an error 
'Specified 'sqlite3' for database adapter, but the gem is not loaded'